### PR TITLE
Add upstream#pathRewrite

### DIFF
--- a/src/middlewares/upstream.ts
+++ b/src/middlewares/upstream.ts
@@ -22,6 +22,7 @@ export const getURL = (
     domain,
     port,
     protocol,
+    pathRewrite,
   } = upstream;
 
   cloneURL.hostname = domain;
@@ -34,6 +35,10 @@ export const getURL = (
     cloneURL.port = '';
   } else {
     cloneURL.port = port.toString();
+  }
+
+  if (pathRewrite) {
+    cloneURL.pathname = pathRewrite(cloneURL.pathname);
   }
 
   return cloneURL.href;

--- a/types/middlewares/upstream.ts
+++ b/types/middlewares/upstream.ts
@@ -4,4 +4,5 @@ export interface UpstreamOptions {
   port?: number;
   timeout?: number;
   weight?: number;
+  pathRewrite?: (p: string) => string;
 }


### PR DESCRIPTION
In my case, I have a single Worker being served on `example.com`, I then have many different cloudflare pages on various subdomains, like `shop.example.com` `admin.example.com` `checkout.example.com`, etc

I want my single worker to be the interface, and to hide these subdomains from my users... I `useUpstream` and `pathRewrite` to have the following request:

```
example.com/checkout
```

Proxied (and rewritten) to `checkout.example.com`

...

Without `pathRewrite`ing, reflare requests `checkout.example.com/checkout` which doesn't work for my use case

closes #352 