### PR TITLE
Allow `onResponse`/`onRequest` to be arrays of functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const filter = (
 
   for (const route of routeList) {
     if (route.methods === undefined || route.methods.includes(request.method)) {
-      const match = convertToArray(route.path).some((path) => {
+      const match = convertToArray<string>(route.path).some((path) => {
         const re = RegExp(
           `^${path
             .replace(/(\/?)\*/g, '($1.*)?')

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import {
 } from './middlewares';
 import { WorkersKV } from './database';
 import { usePipeline } from './middleware';
-import { createResponse, getHostname } from './utils';
+import { createResponse, getHostname, convertToArray } from './utils';
 
 import {
   Reflare,
@@ -25,7 +25,7 @@ const filter = (
 
   for (const route of routeList) {
     if (route.methods === undefined || route.methods.includes(request.method)) {
-      const match = (Array.isArray(route.path) ? route.path : [route.path]).some((path) => {
+      const match = convertToArray(route.path).some((path) => {
         const re = RegExp(
           `^${path
             .replace(/(\/?)\*/g, '($1.*)?')

--- a/src/middlewares/upstream.ts
+++ b/src/middlewares/upstream.ts
@@ -1,5 +1,5 @@
 import { Middleware } from '../../types/middleware';
-import { UpstreamOptions } from '../../types/middlewares/upstream';
+import { UpstreamOptions, onResponseCallback, onRequestCallback } from '../../types/middlewares/upstream';
 
 export const cloneRequest = (
   url: string,
@@ -56,22 +56,37 @@ export const useUpstream: Middleware = async (
     return;
   }
 
-  const { onRequest, onResponse } = upstream;
-
   const url = getURL(
     request.url,
     upstream,
   );
 
-  const upstreamRequest = onRequest
-    ? onRequest(cloneRequest(url, request), url)
-    : cloneRequest(url, request);
+  const onRequest: onRequestCallback[] | null = upstream.onRequest
+    ? Array.isArray(upstream.onRequest)
+      ? upstream.onRequest
+      : [upstream.onRequest]
+    : null;
+
+  const onResponse: onResponseCallback[] | null = upstream.onResponse
+    ? Array.isArray(upstream.onResponse)
+      ? upstream.onResponse
+      : [upstream.onResponse]
+    : null;
+
+    if (onRequest) {
+      upstreamRequest = onRequest.reduce(
+        (prevReq: Request, fn: onRequestCallback) => fn(cloneRequest(url, prevReq), url),
+        upstreamRequest,
+      );
+    }
 
   context.response = await fetch(upstreamRequest);
 
   if (onResponse) {
-    const newResponse = new Response(context.response.body, context.response);
-    context.response = onResponse(newResponse, url);
+    context.response = onResponse.reduce(
+      (prevRes: Response, fn: onResponseCallback) => fn(new Response(prevRes.body, prevRes), url),
+      new Response(context.response.body, context.response),
+    );
   }
 
   await next();

--- a/src/middlewares/upstream.ts
+++ b/src/middlewares/upstream.ts
@@ -1,6 +1,6 @@
 import { Middleware } from '../../types/middleware';
 import { UpstreamOptions, onResponseCallback, onRequestCallback } from '../../types/middlewares/upstream';
-import { convertToArray } from '../utils'
+import { convertToArray } from '../utils';
 
 export const cloneRequest = (
   url: string,
@@ -62,8 +62,13 @@ export const useUpstream: Middleware = async (
     upstream,
   );
 
-  const onRequest: onRequestCallback[] | null = upstream.onRequest ? convertToArray(upstream.onRequest) : null
-  const onResponse: onResponseCallback[] | null = upstream.onResponse ? convertToArray(upstream.onResponse) : null
+  const onRequest = upstream.onRequest
+    ? convertToArray<onRequestCallback>(upstream.onRequest)
+    : null;
+
+  const onResponse = upstream.onResponse
+    ? convertToArray<onResponseCallback>(upstream.onResponse)
+    : null;
 
   let upstreamRequest = cloneRequest(url, request);
 

--- a/src/middlewares/upstream.ts
+++ b/src/middlewares/upstream.ts
@@ -73,12 +73,14 @@ export const useUpstream: Middleware = async (
       : [upstream.onResponse]
     : null;
 
-    if (onRequest) {
-      upstreamRequest = onRequest.reduce(
-        (prevReq: Request, fn: onRequestCallback) => fn(cloneRequest(url, prevReq), url),
-        upstreamRequest,
-      );
-    }
+  let upstreamRequest = cloneRequest(url, request);
+
+  if (onRequest) {
+    upstreamRequest = onRequest.reduce(
+      (prevReq: Request, fn: onRequestCallback) => fn(cloneRequest(url, prevReq), url),
+      upstreamRequest,
+    );
+  }
 
   context.response = await fetch(upstreamRequest);
 

--- a/src/middlewares/upstream.ts
+++ b/src/middlewares/upstream.ts
@@ -1,5 +1,6 @@
 import { Middleware } from '../../types/middleware';
 import { UpstreamOptions, onResponseCallback, onRequestCallback } from '../../types/middlewares/upstream';
+import { convertToArray } from '../utils'
 
 export const cloneRequest = (
   url: string,
@@ -61,23 +62,14 @@ export const useUpstream: Middleware = async (
     upstream,
   );
 
-  const onRequest: onRequestCallback[] | null = upstream.onRequest
-    ? Array.isArray(upstream.onRequest)
-      ? upstream.onRequest
-      : [upstream.onRequest]
-    : null;
-
-  const onResponse: onResponseCallback[] | null = upstream.onResponse
-    ? Array.isArray(upstream.onResponse)
-      ? upstream.onResponse
-      : [upstream.onResponse]
-    : null;
+  const onRequest: onRequestCallback[] | null = upstream.onRequest ? convertToArray(upstream.onRequest) : null
+  const onResponse: onResponseCallback[] | null = upstream.onResponse ? convertToArray(upstream.onResponse) : null
 
   let upstreamRequest = cloneRequest(url, request);
 
   if (onRequest) {
     upstreamRequest = onRequest.reduce(
-      (prevReq: Request, fn: onRequestCallback) => fn(cloneRequest(url, prevReq), url),
+      (prevRequest: Request, fn: onRequestCallback) => fn(cloneRequest(url, prevRequest), url),
       upstreamRequest,
     );
   }
@@ -86,7 +78,7 @@ export const useUpstream: Middleware = async (
 
   if (onResponse) {
     context.response = onResponse.reduce(
-      (prevRes: Response, fn: onResponseCallback) => fn(new Response(prevRes.body, prevRes), url),
+      (prevResponse: Response, fn: onResponseCallback) => fn(new Response(prevResponse.body, prevResponse), url),
       new Response(context.response.body, context.response),
     );
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -42,6 +42,6 @@ export const isSameOrigin = (
   return true;
 };
 
-export const convertToArray = (maybeArray: any): any[] => {
+export const convertToArray = <T>(maybeArray: T | T[]): T[] => {
   return Array.isArray(maybeArray) ? maybeArray : [maybeArray]
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -41,3 +41,7 @@ export const isSameOrigin = (
   }
   return true;
 };
+
+export const convertToArray = (maybeArray: any): any[] => {
+  return Array.isArray(maybeArray) ? maybeArray : [maybeArray]
+};

--- a/tests/middlewares/upstream.test.ts
+++ b/tests/middlewares/upstream.test.ts
@@ -46,17 +46,24 @@ test('upstream -> onRespone', async () => {
     path: '/foo*',
     upstream: {
       domain: 'httpbin.org',
-      onResponse: (res: Response): Response => {
-        const result = 1 + 1;
-        res.headers.set('x-foo', result.toString());
-        return res;
-      },
+      onResponse: [
+        (res: Response): Response => {
+          const result = 1 + 1;
+          res.headers.set('x-foo', result.toString());
+          return res;
+        },
+        (res: Response): Response => {
+          res.headers.set('x-bar', 'foo');
+          return res;
+        }
+      ],
     },
   });
 
   const response = await reflare.handle(request);
 
   expect(response.headers.get('x-foo')).toEqual('2');
+  expect(response.headers.get('x-bar')).toEqual('foo');
 });
 
 test('upstream -> with collection of paths', async () => {

--- a/types/middlewares/upstream.ts
+++ b/types/middlewares/upstream.ts
@@ -1,5 +1,5 @@
-export type onResponseCallback = (k: Response, url: string) => Response;
-export type onRequestCallback = (k: Request, url: string) => Request;
+export type onResponseCallback = (response: Response, url: string) => Response;
+export type onRequestCallback = (request: Request, url: string) => Request;
 
 export interface UpstreamOptions {
   domain: string;

--- a/types/middlewares/upstream.ts
+++ b/types/middlewares/upstream.ts
@@ -1,9 +1,12 @@
+export type onResponseCallback = (k: Response, url: string) => Response;
+export type onRequestCallback = (k: Request, url: string) => Request;
+
 export interface UpstreamOptions {
   domain: string;
   protocol?: 'http' | 'https';
   port?: number;
   timeout?: number;
   weight?: number;
-  onRequest?: (request: Request, url: string) => Request;
-  onResponse?: (response: Response, url: string) => Response;
+  onRequest?: onRequestCallback | onRequestCallback[];
+  onResponse?: onResponseCallback | onResponseCallback[];
 }


### PR DESCRIPTION
Changing the following:

```
onRequest?: onRequestCallback | onRequestCallback[];
onResponse?: onResponseCallback | onResponseCallback[];
```

options to be arrays me to better organize the extensions I'm doing. In a private repo, my code looks like this:

```ts
{
  upstream: {
    domain: ..,
    protocol: ..,
    port: ...,
    onResponse: [
      addCacheControl,
      addBaseSecurityHeaders,
      addFrameSecurityHeader,
      addWantsMobileMobileHeader,
    ],
  }
 }

function addBaseSecurityHeaders(res: Response, url: string): Response {
  for (const [key, value] of Object.entries(securityHeaders)) {
    res.headers.set(key, value);
  }

  return res;
}

function addWantsMobileMobileHeader(res: Response, _url: string): Response {
  res.headers.set('x-wants-mobile', 'true');
  return res;
}

function addFrameSecurityHeader(res: Response, url: string): Response {
  res.headers.set('x-frame-options', 'SAMEORIGIN');

  return res;
}

function addCacheControl(res: Response, url: string): Response {
  const pointsToFile = /\/[^/]+\.[^/]+$/.test(url);

  if (url.endsWith('.html') || url.endsWith('/') || !pointsToFile) {
    // if our request has an HTML exstension OR trailing slash OR doesn't have any extension,
    // [/foo/bar.html, /foo/bar/, /foo/bar]
    // We assume we're serving a document and treating the cache control header as such
    res.headers.set('cache-control', 'public, max-age=240, s-maxage=60');
  } else if (url.includes('_next/')) {
    res.headers.set('cache-control', 'public, max-age=31536000, immutable');
  } else if (url.includes('.')) {
    res.headers.set('cache-control', 'public, max-age=86400, s-maxage=300');
  }

  return res;
}
```

Is much cleaner than having a single onResponse function. I'm reverse proxying many frontend/backend applications with subtle differences in how manage headers.