### PR TITLE
Support multiple domain names for a reflare instance

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,23 @@ const filter = (
   const url = new URL(request.url);
 
   for (const route of routeList) {
+    if (route.domain) {
+      const matchDomain = castToIterable<string>(route.domain).some((domain) => {
+        const re = RegExp(
+          `^${domain
+            .replace(/(\/?)\*/g, '($1.*)?')
+            .replace(/\/$/, '')
+            .replace(/:(\w+)(\?)?(\.)?/g, '$2(?<$1>[^/]+)$2$3')
+            .replace(/\.(?=[\w(])/, '\\.')
+            .replace(/\)\.\?\(([^[]+)\[\^/g, '?)\\.?($1(?<=\\.)[^\\.')}/*$`,
+        );
+        return url.hostname.match(re);
+      });
+      if (!matchDomain) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+    }
     if (route.methods === undefined || route.methods.includes(request.method)) {
       const match = castToIterable<string>(route.path).some((path) => {
         const re = RegExp(

--- a/tests/middlewares/upstream.test.ts
+++ b/tests/middlewares/upstream.test.ts
@@ -75,3 +75,32 @@ test('upstream.ts -> with collection of paths', async () => {
   expect(response.status).toBe(200);
   expect(response.url).toBe('https://httpbingo.org/get');
 });
+
+test('upstream.ts -> with domain', async () => {
+  const request = new Request('https://example.com/get');
+
+  const reflare = await useReflare();
+  reflare.push({
+    domain: 'example.com',
+    path: '/*',
+    upstream: { domain: 'httpbingo.org' },
+  });
+
+  const response = await reflare.handle(request);
+  expect(response.status).toBe(200);
+  expect(response.url).toBe('https://httpbingo.org/get');
+});
+
+test('upstream.ts -> no matched domain', async () => {
+  const request = new Request('https://localhost/get');
+
+  const reflare = await useReflare();
+  reflare.push({
+    domain: 'example.com',
+    path: '/*',
+    upstream: { domain: 'httpbingo.org' },
+  });
+
+  const response = await reflare.handle(request);
+  expect(response.status).toBe(500);
+});

--- a/types/index.ts
+++ b/types/index.ts
@@ -7,6 +7,7 @@ import {
 } from './middlewares';
 
 export interface Route {
+  domain?: string | string[];
   path: string | string[];
   upstream: UpstreamOptions | UpstreamOptions[];
   firewall?: FirewallOptions[];


### PR DESCRIPTION
In my use case, I hope to use a worker that can reverse proxy multiple domains to their corresponding apps. 
For example: 
```
app1.example.com -> app1-xxx-as.a.run.app 
app2.example.com -> app2-xxx.vercel.app
```
Therefore, in the route definition, add an optional "domain" field for domain matching.

Usage will be like: 
```javascript
reflare.push({
	domain: 'app1.example.com',
	path: '/*',
	upstream: {
		protocol: 'https',
		domain: 'app1-xxx-as.a.run.app ,
	}
});
```

Can you help me review this PR? If there are other questions, I can modify it, thanks
